### PR TITLE
Check only units in PDF regex stage

### DIFF
--- a/patterns.py
+++ b/patterns.py
@@ -1,12 +1,11 @@
 import re
 
 # базовые куски
-NUM = r'(?:\d+(?:[\.,]\d+)?(?:\s*[×x]\s*10\^[-+]?\d+)?|\d+(?:\.\d+)?[eE][-+]?\d+)'
-SP  = r'(?:\s|&nbsp;| | | )*'
 INV = r'(?:-1|⁻1|\\?-1|\\?⁻1)'
 
 # единицы для dose constant
 DOSE_UNITS = rf'(?:k?Gy{INV}|rad{INV}|krad{INV})'
+DOSE_UNITS_RE = re.compile(DOSE_UNITS, re.IGNORECASE)
 
 # единицы для G/RCY (в тексте допускаем и отсутствие единиц)
 G_UNITS = (
@@ -16,16 +15,5 @@ G_UNITS = (
     r'(?:μ|µ|u|m|)?mol\s*/\s*J'
     r')'
 )
+G_UNITS_RE = re.compile(G_UNITS, re.IGNORECASE)
 
-# dose constant и синонимы (k_d/kd/k) + единицы вблизи
-DOSE_CONST_NEAR = re.compile(
-    rf'\b(?:dose{SP}constant|radiation{SP}dose{SP}constant|k[_\-]?d|kd|\bk\b){SP}[:=]?\s*(?:{NUM})?[^\n]{{0,50}}{DOSE_UNITS}',
-    re.IGNORECASE
-)
-
-# разрешаем: G-value | RCY | G(-...)=число [+опц.единицы]
-G_VALUE_ANY = re.compile(
-    rf'(?:\bG{SP}-?{SP}value\b|\bradiation{SP}chemical{SP}yield\b|\bG\s*\(-[^)]+\))'
-    rf'{SP}[:=]?\s*{NUM}(?:{SP}(?:{G_UNITS}))?',
-    re.IGNORECASE
-)

--- a/pipeline.py
+++ b/pipeline.py
@@ -10,7 +10,7 @@ from search import (
 from download import try_download_pdf_with_validation, try_download_xml
 from extract import extract_text_from_pdf, extract_text_from_xml, extract_tables_text
 from inventory import load_seen_inventory, ensure_inventory_file, append_inventory_row
-from patterns import DOSE_CONST_NEAR, G_VALUE_ANY
+from patterns import DOSE_UNITS_RE, G_UNITS_RE
 
 def _merge_sources(*dicts) -> dict[str, dict]:
     db: dict[str, dict] = {}
@@ -91,9 +91,9 @@ def run_pipeline(max_per_source=200):
                 gamma_in_text = mentions_gamma(full_text, GAMMA_HINTS)
             gamma_flag = gamma_in_ta or gamma_in_text
             if gamma_flag:
-                if DOSE_CONST_NEAR.search(full_text):
+                if DOSE_UNITS_RE.search(full_text):
                     dose_const_found = True
-                if G_VALUE_ANY.search(full_text):
+                if G_UNITS_RE.search(full_text):
                     g_value_found = True
             (TEXT_DIR / f"{doi_to_fname(rec_id)}.txt").write_text(full_text, encoding="utf-8", errors="ignore")
 


### PR DESCRIPTION
## Summary
- Detect measurement units in full text without requiring dose constant or G-value terms
- Expose unit-only regex patterns for dose and G/RCY checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c09d99b854832ba488dc64c2850b51