### PR TITLE
Use LibGen for PDF fallback downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pdfminer.six>=20221105",
   "beautifulsoup4>=4.12",
   "lxml>=4.9",
+  "libgen-api-enhanced>=1.2",
   "pandas>=2.0"
 ]
 


### PR DESCRIPTION
## Summary
- replace Sci-Hub download stub with libgen-api-enhanced
- add libgen-api-enhanced dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c12e0064f8832bb8762975a6e934e5