### PR TITLE
Make parser configurable for arbitrary properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Articles Parser
 
-Проект Articles Parser предназначен для автоматизации процесса сбора и обработки научных публикаций. Он позволяет автоматически находить статьи в различных источниках, фильтровать их по заданным критериям, скачивать полные тексты, извлекать содержимое и сохранять результаты для дальнейшего анализа.
+Проект Articles Parser предназначен для автоматизации процесса сбора и обработки научных публикаций. Он позволяет автоматически находить статьи в различных источниках, фильтровать их по заданным пользователем критериям, скачивать полные тексты, извлекать содержимое и сохранять результаты для дальнейшего анализа. Парсер универсален и может собирать данные о любых химических или физических свойствах.
 
 ## Этапы работы
 
@@ -30,5 +30,27 @@ pip install -r requirements.txt
 3. Запуск парсера:
 
 ```bash
-python cli.py --max-per-source <number_of_articles>
+python cli.py --keywords water viscosity \
+    --abstract-filter --abstract-patterns temperature \
+    --property-filter names --property-names viscosity "dynamic viscosity" \
+    --oa-only --max-per-source 50 --output-dir ./output
 ```
+
+Параметры можно комбинировать в зависимости от задачи. Скрипт также можно
+использовать как библиотеку:
+
+```python
+from articles_parser import run_pipeline
+
+run_pipeline(
+    keywords=["water", "viscosity"],
+    abstract_filter=True,
+    abstract_patterns=["temperature"],
+    property_names_units_filter="names",
+    property_names=["viscosity", "dynamic viscosity"],
+    oa_only=True,
+    max_per_source=50,
+    output_directory="./output",
+)
+```
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,3 @@
 # re-export удобных точек входа
 from .pipeline import run_pipeline
+

--- a/cli.py
+++ b/cli.py
@@ -2,15 +2,41 @@ import sys
 import argparse
 from pipeline import run_pipeline
 
+
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Gamma radiolysis DB builder")
-    parser.add_argument("--max-per-source", type=int, default=200, help="сколько записей запрашивать у каждого источника")
+    parser = argparse.ArgumentParser(description="Universal articles parser")
+    parser.add_argument("--keywords", nargs="+", required=True, help="search keywords")
+    parser.add_argument("--abstract-filter", action="store_true", help="enable abstract filtering")
+    parser.add_argument("--abstract-patterns", nargs="*", default=[], help="patterns that must appear in abstract")
+    parser.add_argument(
+        "--property-filter",
+        choices=["names", "units", "names_units"],
+        default=None,
+        help="filter full texts by property names/units",
+    )
+    parser.add_argument("--property-names", nargs="*", default=[], help="property name synonyms")
+    parser.add_argument("--property-units", nargs="*", default=[], help="property units")
+    parser.add_argument("--oa-only", action="store_true", help="only download open access articles")
+    parser.add_argument("--max-per-source", type=int, default=None, help="limit of records per source")
+    parser.add_argument("--output-dir", default="data", help="directory for output data")
     args = parser.parse_args(argv)
-    run_pipeline(max_per_source=args.max_per_source)
+
+    run_pipeline(
+        keywords=args.keywords,
+        abstract_filter=args.abstract_filter,
+        abstract_patterns=args.abstract_patterns,
+        property_names_units_filter=args.property_filter,
+        property_names=args.property_names,
+        property_units=args.property_units,
+        oa_only=args.oa_only,
+        max_per_source=args.max_per_source,
+        output_directory=args.output_dir,
+    )
+
 
 if __name__ == "__main__":
-    # поддержка jupyter: не передавать лишние аргументы
     if "ipykernel_launcher" in sys.argv[0]:
         main([])
     else:
         main()
+

--- a/config.py
+++ b/config.py
@@ -1,29 +1,19 @@
 from pathlib import Path
 import os
 
-# Ключевые термины поиска
-KEY_TERMS = [
-    "radiolysis",
-    "dose constant",
-    "G-value",
-    "radiation chemical yield",
-    "radiolytic stability",
-    "radiolytic degradation",
-]
+# Ключевые термины поиска (устанавливаются во время выполнения)
+KEY_TERMS: list[str] = []
 
-# Подсказки про гамма
-GAMMA_HINTS = [
-    "gamma", "γ", "gamma-ray", "gamma radiation", "gamma irradiation",
-    "co-60", "cobalt-60", "cs-137", "cesium-137", "cobalt 60",
-    "caesium-137", "60co", "137cs"
-]
+def set_keywords(keywords: list[str]) -> None:
+    """Set search keywords used by search modules."""
+    global KEY_TERMS
+    KEY_TERMS = keywords or []
 
 # HTTP / API
 REQUESTS_TIMEOUT = 30
 RATE_LIMIT_SLEEP = 0.5
-#HEADERS = {"User-Agent": "gamma-radiolysis-db-builder/3.1"}
 
-# Пути
+# Пути (могут быть переопределены пользователем)
 DATA_DIR = Path("data")
 PDF_DIR = DATA_DIR / "pdfs"
 XML_DIR = DATA_DIR / "xmls"
@@ -33,6 +23,19 @@ LOG_INVENTORY = DATA_DIR / "inventory.csv"
 LOG_PDF_DOI = DATA_DIR / "pdf_doi.txt"
 LOG_XML_DOI = DATA_DIR / "xml_doi.txt"
 LOG_DOI_NOT_DOWNL = DATA_DIR / "doi_not_downl.txt"
+
+def set_output_dir(path: str | Path) -> None:
+    """Adjust all output paths to a new base directory."""
+    global DATA_DIR, PDF_DIR, XML_DIR, TEXT_DIR
+    global LOG_INVENTORY, LOG_PDF_DOI, LOG_XML_DOI, LOG_DOI_NOT_DOWNL
+    DATA_DIR = Path(path)
+    PDF_DIR = DATA_DIR / "pdfs"
+    XML_DIR = DATA_DIR / "xmls"
+    TEXT_DIR = DATA_DIR / "texts"
+    LOG_INVENTORY = DATA_DIR / "inventory.csv"
+    LOG_PDF_DOI = DATA_DIR / "pdf_doi.txt"
+    LOG_XML_DOI = DATA_DIR / "xml_doi.txt"
+    LOG_DOI_NOT_DOWNL = DATA_DIR / "doi_not_downl.txt"
 
 # Unpaywall
 UNPAYWALL_EMAIL = "vorfight@gmail.com" #os.environ.get("UNPAYWALL_EMAIL", "").strip()

--- a/inventory.py
+++ b/inventory.py
@@ -6,9 +6,9 @@ from config import LOG_INVENTORY
 
 COLUMNS = [
     "doi", "title", "source",
-    "abstract_available", "gamma_in_ta", "gamma_in_text",
+    "abstract_available", "abstract_matched",
     "pdf_downloaded", "xml_downloaded",
-    "dose_const_found", "g_value_found",
+    "names_found", "units_found",
     "notes"
 ]
 


### PR DESCRIPTION
## Summary
- Allow setting search keywords and output directory at runtime
- Add flexible filters: abstract patterns, property names/units, OA-only download
- Expand CLI/README for universal chemical or physical property parsing

## Testing
- `python -m py_compile config.py download.py inventory.py pipeline.py cli.py`
- `python cli.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c144cf4a00832b97caca4c5f509e6a