### PR TITLE
Add SciHub fallback for LibGen failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "beautifulsoup4>=4.12",
   "lxml>=4.9",
   "libgen-api-enhanced>=1.2",
+  "scidownl>=1.0",
   "pandas>=2.0"
 ]
 


### PR DESCRIPTION
## Summary
- fallback to scidownl's SciHub downloader when LibGen cannot provide a direct link
- add scidownl as a project dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c438e8fcf0832ba70cf8e4ff7b3130