### PR TITLE
Add separate Elsevier API keys for search and download

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,4 +38,7 @@ def set_output_dir(path: str | Path) -> None:
 
 # Unpaywall
 UNPAYWALL_EMAIL = "vorfight@gmail.com"  # os.environ.get("UNPAYWALL_EMAIL", "").strip()
-ELSEVIER_API_KEY = "7f59af901d2d86f78a1fd60c1bf9426a"  # os.environ.get("ELSEVIER_API_KEY", "").strip()
+
+# Elsevier
+ELSEVIER_SEARCH_API_KEY = "7f59af901d2d86f78a1fd60c1bf9426a"  # os.environ.get("ELSEVIER_SEARCH_API_KEY", "").strip()
+ELSEVIER_DOWNLOAD_API_KEY = "7f59af901d2d86f78a1fd60c1bf9426a"  # os.environ.get("ELSEVIER_DOWNLOAD_API_KEY", "").strip()

--- a/download.py
+++ b/download.py
@@ -17,8 +17,9 @@ def _is_elsevier_content_url(url: str | None) -> bool:
 
 def _elsevier_headers(accept: str) -> dict[str, str]:
     headers = {"Accept": accept}
-    if config.ELSEVIER_API_KEY:
-        headers["X-ELS-APIKey"] = config.ELSEVIER_API_KEY
+    api_key = config.ELSEVIER_DOWNLOAD_API_KEY or config.ELSEVIER_SEARCH_API_KEY
+    if api_key:
+        headers["X-ELS-APIKey"] = api_key
     return headers
 
 def append_line(path: Path, doi: str):

--- a/search/crossref.py
+++ b/search/crossref.py
@@ -9,6 +9,7 @@ def search_crossref(keywords: list[str], max_records=200):
     base = "https://api.crossref.org/works"
     rows = 100
     results = {}
+    download_key = config.ELSEVIER_DOWNLOAD_API_KEY or config.ELSEVIER_SEARCH_API_KEY
     pbar = tqdm(total=max_records * len(keywords), desc="Crossref search", unit="rec")
     for kw in keywords:
         cursor = "*"
@@ -28,8 +29,18 @@ def search_crossref(keywords: list[str], max_records=200):
                 if "abstract" in it and isinstance(it["abstract"], str):
                     abstr = BeautifulSoup(it["abstract"], "lxml").get_text(" ", strip=True)
 
-                pdf_url = f"https://api.elsevier.com/content/article/doi/{quote_plus(doi)}?httpAccept=application/pdf&apiKey={config.ELSEVIER_API_KEY}"
-                xml_url = f"https://api.elsevier.com/content/article/doi/{quote_plus(doi)}?httpAccept=application/xml&apiKey={config.ELSEVIER_API_KEY}"
+                pdf_url = None
+                xml_url = None
+                if download_key:
+                    doi_path = quote_plus(doi)
+                    pdf_url = (
+                        "https://api.elsevier.com/content/article/doi/"
+                        f"{doi_path}?httpAccept=application/pdf&apiKey={download_key}"
+                    )
+                    xml_url = (
+                        "https://api.elsevier.com/content/article/doi/"
+                        f"{doi_path}?httpAccept=application/xml&apiKey={download_key}"
+                    )
 
                 results[doi] = {
                     "source": "crossref",


### PR DESCRIPTION
## Summary
- add dedicated Elsevier API keys for search and download in the configuration
- update ScienceDirect and Crossref search modules to rely on the search key for queries and the download key for content URLs
- ensure Elsevier downloads send the download API key in request headers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2a9ac3154832bb68dcaec2e72a6d6