### PR TITLE
Add verbose flag to control pipeline output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python cli.py --keywords "oil viscosity" "petrol viscosity" \
     --sources OpenAlex Sciencedirect
 ```
 
+Add `--no-verbose` to hide detailed per-article output and only keep the search progress bars.
+
 Parameters can be combined as needed. The package can also be used as a library:
 
 ```python
@@ -50,6 +52,7 @@ run_pipeline(
     max_per_source=50,
     output_directory="./output",
     sources=["OpenAlex", "Sciencedirect"],
+    verbose=True,
 )
 ```
 

--- a/cli.py
+++ b/cli.py
@@ -25,6 +25,19 @@ def main(argv=None):
         default=[],
         help="list of sources to search (e.g. OpenAlex Sciencedirect)",
     )
+    parser.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        default=True,
+        help="enable detailed per-article output",
+    )
+    parser.add_argument(
+        "--no-verbose",
+        dest="verbose",
+        action="store_false",
+        help="disable detailed per-article output",
+    )
     args = parser.parse_args(argv)
 
     run_pipeline(
@@ -38,6 +51,7 @@ def main(argv=None):
         max_per_source=args.max_per_source,
         output_directory=args.output_dir,
         sources=args.sources or None,
+        verbose=args.verbose,
     )
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -51,7 +51,8 @@ def run_pipeline(
     max_per_source: int | None = None,
     output_directory: str | Path = "data",
     sources: list[str] | None = None,
-    libgen_domain: str | None = "bz"
+    libgen_domain: str | None = "bz",
+    verbose: bool = True,
 ):
     """Execute full pipeline of search, download and filtering."""
 
@@ -87,11 +88,13 @@ def run_pipeline(
     )
 
     for kw in keywords:
-        print(f"\n=== Keyword: {kw} ===")
+        if verbose:
+            print(f"\n=== Keyword: {kw} ===")
         config.set_keywords([kw])
         searches = [src_funcs[s]([kw], max_records) for s in selected]
         db = _merge_sources(*searches)
-        print(f"Total unique records for '{kw}': {len(db)}")
+        if verbose:
+            print(f"Total unique records for '{kw}': {len(db)}")
 
         for rec_id, rec in db.items():
             nd = norm_doi(rec_id) or rec_id
@@ -158,12 +161,13 @@ def run_pipeline(
                 }
                 append_inventory_row(row)
                 seen.add(nd)
-                report_lines.append(f"  Direct download: {direct_status}")
-                report_lines.append(f"  Libgen download: {libgen_status}")
-                if property_message:
-                    report_lines.append(f"  Property filter: {property_message}")
-                print("\n".join(report_lines))
-                print()
+                if verbose:
+                    report_lines.append(f"  Direct download: {direct_status}")
+                    report_lines.append(f"  Libgen download: {libgen_status}")
+                    if property_message:
+                        report_lines.append(f"  Property filter: {property_message}")
+                    print("\n".join(report_lines))
+                    print()
                 continue
 
             pdf_result = try_download_pdf_with_validation(
@@ -220,10 +224,11 @@ def run_pipeline(
                     property_message = f"{label}: patterns not in text (no full text available)"
             # no extraction if property_names_units_filter is None
 
-            report_lines.append(f"  Direct download: {direct_status}")
-            report_lines.append(f"  Libgen download: {libgen_status}")
-            if property_message:
-                report_lines.append(f"  Property filter: {property_message}")
+            if verbose:
+                report_lines.append(f"  Direct download: {direct_status}")
+                report_lines.append(f"  Libgen download: {libgen_status}")
+                if property_message:
+                    report_lines.append(f"  Property filter: {property_message}")
 
             row = {
                 "doi": nd,
@@ -240,7 +245,9 @@ def run_pipeline(
             }
             append_inventory_row(row)
             seen.add(nd)
-            print("\n".join(report_lines))
-            print()
-    print(f"Done. Summary in {config.LOG_INVENTORY}")
+            if verbose:
+                print("\n".join(report_lines))
+                print()
+    if verbose:
+        print(f"Done. Summary in {config.LOG_INVENTORY}")
 


### PR DESCRIPTION
## Summary
- add CLI options to toggle verbose output for per-article logging
- propagate the verbose flag through the pipeline to gate detailed printouts
- document how to disable verbose mode and expose the flag in the Python API example

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dada7a3428832b97469fa353176758