### PR TITLE
Ensure pipeline output is flushed for long nohup runs

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -89,12 +89,12 @@ def run_pipeline(
 
     for kw in keywords:
         if verbose:
-            print(f"\n=== Keyword: {kw} ===")
+            print(f"\n=== Keyword: {kw} ===", flush=True)
         config.set_keywords([kw])
         searches = [src_funcs[s]([kw], max_records) for s in selected]
         db = _merge_sources(*searches)
         if verbose:
-            print(f"Total unique records for '{kw}': {len(db)}")
+            print(f"Total unique records for '{kw}': {len(db)}", flush=True)
 
         for rec_id, rec in db.items():
             nd = norm_doi(rec_id) or rec_id
@@ -166,8 +166,8 @@ def run_pipeline(
                     report_lines.append(f"  Libgen download: {libgen_status}")
                     if property_message:
                         report_lines.append(f"  Property filter: {property_message}")
-                    print("\n".join(report_lines))
-                    print()
+                    print("\n".join(report_lines), flush=True)
+                    print(flush=True)
                 continue
 
             pdf_result = try_download_pdf_with_validation(
@@ -246,8 +246,8 @@ def run_pipeline(
             append_inventory_row(row)
             seen.add(nd)
             if verbose:
-                print("\n".join(report_lines))
-                print()
+                print("\n".join(report_lines), flush=True)
+                print(flush=True)
     if verbose:
-        print(f"Done. Summary in {config.LOG_INVENTORY}")
+        print(f"Done. Summary in {config.LOG_INVENTORY}", flush=True)
 

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,7 @@ def safe_request_json(url, params=None, headers=None):
         r.raise_for_status()
         return r.json()
     except Exception as e:
-        print(e)
+        print(e, flush=True)
         return None
 
 def safe_get(url, stream=False, headers=None, params=None):


### PR DESCRIPTION
## Summary
- force verbose pipeline logging to flush immediately so progress messages continue to appear when stdout is fully buffered (e.g. under nohup)
- flush error messages produced by `safe_request_json` to avoid buffered exceptions in headless execution

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68daee3e4c00832b8df9a1d4a0a8ef74