### PR TITLE
Add local PDF validation helper and save_text flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ python cli.py --keywords "oil viscosity" "petrol viscosity" \
     --abstract-filter --abstract-patterns temperature \
     --property-filter names --property-names "kinematic viscosity" "dynamic viscosity" \
     --oa-only --max-per-source 50 --output-dir ./output \
+    --save-text \
     --sources OpenAlex Sciencedirect
 ```
 
 Add `--no-verbose` to hide detailed per-article output and only keep the search progress bars.
+Use `--no-save-text` to skip storing extracted `.txt` files alongside downloaded articles.
 
 Parameters can be combined as needed. The package can also be used as a library:
 
@@ -53,6 +55,22 @@ run_pipeline(
     output_directory="./output",
     sources=["OpenAlex", "Sciencedirect"],
     verbose=True,
+    save_text=True,
+)
+```
+
+To validate a locally stored PDF without running the full search pipeline:
+
+```python
+from pipeline import run_local
+
+run_local(
+    pdf_path="/path/to/article.pdf",
+    property_names_units_filter="names_units",
+    property_names=["kinematic viscosity", "dynamic viscosity"],
+    property_units=["mm^2/s", "Pa·s"],
+    inventory=False,
+    save_text=True,
 )
 ```
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
 # Re-export convenient entry points
-from .pipeline import run_pipeline
+from .pipeline import run_pipeline, run_local

--- a/cli.py
+++ b/cli.py
@@ -38,6 +38,19 @@ def main(argv=None):
         action="store_false",
         help="disable detailed per-article output",
     )
+    parser.add_argument(
+        "--save-text",
+        dest="save_text",
+        action="store_true",
+        default=True,
+        help="store extracted text files for downloaded articles",
+    )
+    parser.add_argument(
+        "--no-save-text",
+        dest="save_text",
+        action="store_false",
+        help="do not store extracted text files for downloaded articles",
+    )
     args = parser.parse_args(argv)
 
     run_pipeline(
@@ -52,6 +65,7 @@ def main(argv=None):
         output_directory=args.output_dir,
         sources=args.sources or None,
         verbose=args.verbose,
+        save_text=args.save_text,
     )
 
 


### PR DESCRIPTION
## Summary
- revert the pipeline API to keyword-based execution while adding a `save_text` toggle for text export
- introduce a `run_local` helper that validates locally stored PDFs with optional text persistence and inventory logging
- document and expose the new options in the CLI and README

## Testing
- python -m compileall pipeline.py cli.py __init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfc627440832bb10e6f2b602552b3