### PR TITLE
Refactor fulltext filtering configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Articles Parser automates the collection and processing of scientific publicatio
 2. Initial filtering: titles and abstracts are filtered with regular expressions.
 3. Download: full texts are downloaded.
 4. Text extraction: text is extracted from the downloaded files.
-5. Secondary filtering: full text is filtered for target properties and their units using regular expressions.
+5. Secondary filtering: full text is filtered with user-provided regular expressions.
 
 ## Usage
 
@@ -29,8 +29,8 @@ pip install -r requirements.txt
 
 ```bash
 python cli.py --keywords "oil viscosity" "petrol viscosity" \
-    --abstract-filter --abstract-patterns temperature \
-    --property-filter names --property-names "kinematic viscosity" "dynamic viscosity" \
+    --abstract-filter --abstract-regex temperature \
+    --fulltext-filter --fulltext-regex "kinematic viscosity" "dynamic viscosity" \
     --oa-only --max-per-source 50 --output-dir ./output \
     --save-text \
     --sources OpenAlex Sciencedirect
@@ -47,9 +47,9 @@ from pipeline import run_pipeline
 run_pipeline(
     keywords=["oil viscosity", "petrol viscosity"],
     abstract_filter=True,
-    abstract_patterns=["temperature"],
-    property_names_units_filter="names",
-    property_names=["kinematic viscosity", "dynamic viscosity"],
+    abstract_regex=["temperature"],
+    fulltext_filter=True,
+    fulltext_regex=["kinematic viscosity", "dynamic viscosity"],
     oa_only=True,
     max_per_source=50,
     output_directory="./output",
@@ -66,9 +66,8 @@ from pipeline import run_local
 
 run_local(
     pdf_path="/path/to/article.pdf",
-    property_names_units_filter="names_units",
-    property_names=["kinematic viscosity", "dynamic viscosity"],
-    property_units=["mm^2/s", "Pa·s"],
+    fulltext_filter=True,
+    fulltext_regex=["kinematic viscosity", "mm^2/s"],
     inventory=False,
     save_text=True,
 )

--- a/cli.py
+++ b/cli.py
@@ -7,15 +7,14 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description="Universal articles parser")
     parser.add_argument("--keywords", nargs="+", required=True, help="search keywords")
     parser.add_argument("--abstract-filter", action="store_true", help="enable abstract filtering")
-    parser.add_argument("--abstract-patterns", nargs="*", default=[], help="patterns that must appear in abstract")
+    parser.add_argument("--abstract-regex", nargs="*", default=[], help="regular expressions that must appear in abstract")
+    parser.add_argument("--fulltext-filter", action="store_true", help="enable full text regex filtering")
     parser.add_argument(
-        "--property-filter",
-        choices=["names", "units", "names_units"],
-        default=None,
-        help="filter full texts by property names/units",
+        "--fulltext-regex",
+        nargs="*",
+        default=[],
+        help="regular expressions that must appear in full text",
     )
-    parser.add_argument("--property-names", nargs="*", default=[], help="property name synonyms")
-    parser.add_argument("--property-units", nargs="*", default=[], help="property units")
     parser.add_argument("--oa-only", action="store_true", help="only download open access articles")
     parser.add_argument("--max-per-source", type=int, default=None, help="limit of records per source")
     parser.add_argument("--output-dir", default="data", help="directory for output data")
@@ -56,10 +55,9 @@ def main(argv=None):
     run_pipeline(
         keywords=args.keywords,
         abstract_filter=args.abstract_filter,
-        abstract_patterns=args.abstract_patterns,
-        property_names_units_filter=args.property_filter,
-        property_names=args.property_names,
-        property_units=args.property_units,
+        abstract_regex=args.abstract_regex,
+        fulltext_filter=args.fulltext_filter,
+        fulltext_regex=args.fulltext_regex,
         oa_only=args.oa_only,
         max_per_source=args.max_per_source,
         output_directory=args.output_dir,

--- a/inventory.py
+++ b/inventory.py
@@ -8,7 +8,7 @@ COLUMNS = [
     "doi", "title", "source", "keyword",
     "abstract_available", "abstract_matched",
     "pdf_downloaded", "xml_downloaded",
-    "names_found", "units_found",
+    "fulltext_matched",
     "notes",
 ]
 


### PR DESCRIPTION
## Summary
- replace property-specific filtering parameters with generic full text regular expression support in both pipeline entry points
- update CLI flags, README usage examples, and inventory schema to reflect the new abstract/fulltext regex options
- ensure local PDF processing returns a full text filter summary consistent with the pipeline output

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfe1191b1c832bbbee78d2b3dc2c4c